### PR TITLE
Fix pages workflow and TypeScript config

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/package.json
+++ b/package.json
@@ -45,12 +45,15 @@
     "rimraf": "^3.0.2",
     "style-loader": "^1.1.4",
     "ts-loader": "^7.0.1",
-    "typescript": "^3.8.3",
+    "typescript": "^5.4.5",
     "webpack": "^4.43.0",
     "webpack-bundle-analyzer": "^3.7.0",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.10.3",
     "webpack-merge": "^4.2.2",
     "webpack-subresource-integrity": "^1.5.1"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.27.6"
   }
 }

--- a/src/view/dice-controls.tsx
+++ b/src/view/dice-controls.tsx
@@ -4,7 +4,8 @@ import Symbols from "src/model/symbols";
 import { AllowedDice, GenesysDie, AbilityDie, ProficiencyDie, BoostDie, DifficultyDie, ChallengeDie, SetbackDie, PercentileDie } from "src/model/dice";
 import DiceDisplay from "src/view/display/dice";
 
-const diceToCreate: ({ cls: typeof GenesysDie, result: GenesysDie["currentResult"] } | { cls: typeof PercentileDie, result: number })[] = [
+type DieCreator<T extends AllowedDice> = { cls: new () => T, result: T["currentResult"] };
+const diceToCreate: DieCreator<AllowedDice>[] = [
     { cls: AbilityDie,     result: [Symbols.SUCCESS] },
     { cls: ProficiencyDie, result: [Symbols.TRIUMPH] },
     { cls: BoostDie,       result: [Symbols.ADVANTAGE] },

--- a/src/view/main-app-area.tsx
+++ b/src/view/main-app-area.tsx
@@ -89,7 +89,9 @@ export default class MainAppArea extends React.Component<{}, { dice: AllowedDice
         if (!webhook || !this.resultsRef.current) { return; }
 
         const canvas = await html2canvas(this.resultsRef.current);
-        const blob: Blob = await new Promise(resolve => canvas.toBlob(b => resolve(b!), "image/png"));
+        const blob: Blob = await new Promise(resolve =>
+            canvas.toBlob((b: Blob | null) => resolve(b!), "image/png")
+        );
 
         const form = new FormData();
         form.append("file", blob, "roll.png");

--- a/styles/components/menu.less
+++ b/styles/components/menu.less
@@ -3,7 +3,6 @@
     left: 0;
     top: 0;
     padding: @padding;
-    background: @dice-area;
     box-shadow: 0 0 4px rgba(0,0,0,0.5);
     display: flex;
     flex-direction: column;

--- a/styles/theming.less
+++ b/styles/theming.less
@@ -20,6 +20,10 @@ button {
     .die.selected::before { outline-color: @dice-selected; }
 }
 
+.menu {
+    background: @dice-area;
+}
+
 .roll-results {
     &.neutral { background: @results-neutral; }
     &.success { background: @results-success; }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,8 @@
     "module": "es6",
     "target": "es6",
     "jsx": "react",
-    "allowJs": true
+    "allowJs": true,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true
   }
 }


### PR DESCRIPTION
## Summary
- update GitHub Pages workflow to use pnpm v9
- bump TypeScript to 5.4.5
- skip type checks for libs
- fix Less theme variable and TypeScript errors
- add @babel/runtime dependency for redux

## Testing
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68557c70eecc8321bc4298dbe28ecf84