### PR TITLE
Improve logo scaling on large screens

### DIFF
--- a/styles/layout.less
+++ b/styles/layout.less
@@ -28,6 +28,10 @@ html, body {
         font-family: genesys-header;
         font-size: 3rem;
 
+        @media (min-width: 48rem) {
+            font-size: 4rem;
+        }
+
         text-align: center;
         @media (min-width: 24rem) {
             text-align: left;
@@ -36,8 +40,8 @@ html, body {
 
         .logo {
             display: inline-block;
-            width: 3rem;
-            height: 3rem;
+            width: 1em;
+            height: 1em;
             margin-right: 0.5rem;
             background: data-uri("assets/logo.png") center/contain no-repeat;
             text-indent: -9999px;


### PR DESCRIPTION
## Summary
- scale page header on screens wider than 48rem
- size the logo using `em` units so it grows with the heading

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68586a73282483219a9a2c251cb420b7