### PR TITLE
Improve Discord output

### DIFF
--- a/src/util/adjudicate.ts
+++ b/src/util/adjudicate.ts
@@ -48,7 +48,5 @@ export function adjudicateRoll(symbols: Symbols[]): Result {
           countSuccess = (counts[Symbols.TRIUMPH] || 0) + (counts[Symbols.SUCCESS] || 0),
           countFailure = (counts[Symbols.DESPAIR] || 0) + (counts[Symbols.FAILURE] || 0);
 
-    console.warn("COUNT: ", counts);
-
     return (countSuccess - countFailure > 0) ? Result.SUCCESS : Result.FAILURE;
 }

--- a/src/view/main-app-area.tsx
+++ b/src/view/main-app-area.tsx
@@ -118,7 +118,7 @@ export default class MainAppArea extends React.Component<{}, { dice: AllowedDice
             if (Array.isArray(r)) { symbols.push(...r); } else if (typeof r === "number") { numbers.push(r); }
         });
         const flat = removeOpposingSymbols(symbols).sort(orderSymbols);
-        const result = adjudicateRoll(flat);
+        const result = symbols.length ? adjudicateRoll(flat) : Result.NEUTRAL;
         const counts = new Map<Symbols, number>();
         flat.forEach(s => counts.set(s, (counts.get(s) || 0) + 1));
         const names: Record<Symbols, string> = {
@@ -138,15 +138,15 @@ export default class MainAppArea extends React.Component<{}, { dice: AllowedDice
     render() {
         return <div className="dice-area">
             <DiceControls callback={this.addDie}/>
-            <DiceList dice={this.state.dice} selected={this.state.selected} selectCallback={this.toggleSelection} />
+            <div ref={this.resultsRef}>
+                <DiceList dice={this.state.dice} selected={this.state.selected} selectCallback={this.toggleSelection} />
+                <RollResults results={this.state.results} />
+            </div>
             <div className="actions">
                 <button id="roll" onClick={this.roll}>{this.state.selected.length ? "Re-roll Selected" : "Roll"}</button>
                 <button id="clear" onClick={this.clearDice}>{this.state.selected.length ? "Remove Selected" : "Clear"}</button>
                   {getWebhook() && !AutoDiscord.get() && this.state.results.length > 0 &&
                     <button id="discord" onClick={this.sendToDiscord}>Отправить в Discord</button>}
-            </div>
-            <div ref={this.resultsRef}>
-                <RollResults results={this.state.results} />
             </div>
         </div>;
     }


### PR DESCRIPTION
## Summary
- fix neutral result calculation for text summary
- remove leftover console log noise
- include the rolled dice in the screenshot sent to Discord

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685e7a04b5f48321b0ce94abb1817f5f