### PR TITLE
Improve Discord screenshot handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@babel/runtime": "^7.27.6"
+        "@babel/runtime": "^7.27.6",
+        "html-to-image": "^1.11.13"
       },
       "devDependencies": {
         "@types/lodash-es": "^4.17.3",
@@ -17,6 +18,7 @@
         "@types/react-dom": "^16.9.5",
         "common_reset": "0.0.6",
         "css-loader": "^3.4.2",
+        "file-loader": "^6.2.0",
         "html-webpack-plugin": "^3.2.0",
         "html2canvas": "^1.4.1",
         "less": "^3.11.1",
@@ -4514,6 +4516,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/html-webpack-plugin": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "webpack-subresource-integrity": "^1.5.1"
   },
   "dependencies": {
-    "@babel/runtime": "^7.27.6"
+    "@babel/runtime": "^7.27.6",
+    "html-to-image": "^1.11.13"
   }
 }

--- a/src/view/main-app-area.tsx
+++ b/src/view/main-app-area.tsx
@@ -3,7 +3,7 @@ import { difference } from "lodash-es";
 
 import { AllowedDice, AllowedResults } from "src/model/dice";
 import { AbilityDie, ProficiencyDie, BoostDie, DifficultyDie, ChallengeDie, SetbackDie, PercentileDie } from "src/model/dice";
-import html2canvas from "html2canvas";
+import { toBlob } from "html-to-image";
 import { getWebhook, Username, AutoDiscord } from "src/model/settings";
 import { removeOpposingSymbols, adjudicateRoll } from "src/util/adjudicate";
 import { orderSymbols } from "src/util/order";
@@ -100,10 +100,8 @@ export default class MainAppArea extends React.Component<{}, { dice: AllowedDice
 
         await new Promise(res => setTimeout(res, 500));
 
-        const canvas = await html2canvas(this.resultsRef.current);
-        const blob: Blob = await new Promise(resolve =>
-            canvas.toBlob((b: Blob | null) => resolve(b!), "image/png")
-        );
+        const blob = await toBlob(this.resultsRef.current, { pixelRatio: 2 });
+        if (!blob) { return; }
 
         const form = new FormData();
         form.append("file", blob, "roll.png");
@@ -140,7 +138,7 @@ export default class MainAppArea extends React.Component<{}, { dice: AllowedDice
     render() {
         return <div className="dice-area">
             <DiceControls callback={this.addDie}/>
-            <div ref={this.resultsRef}>
+            <div ref={this.resultsRef} className="results-container">
                 <DiceList dice={this.state.dice} selected={this.state.selected} selectCallback={this.toggleSelection} />
                 <RollResults results={this.state.results} />
             </div>

--- a/styles/layout.less
+++ b/styles/layout.less
@@ -64,9 +64,15 @@ html, body {
         display: flex;
         flex-direction: column;
 
-        > *          { flex: 0 0 auto; margin: @padding 0 0; }
-        > .dice-list { flex-grow: 1; }
-        .dice-list   { flex-grow: 1; }
+        > *             { flex: 0 0 auto; margin: @padding 0 0; }
+        > .dice-list    { flex-grow: 1; }
+        .dice-list      { flex-grow: 1; }
+        .results-container {
+            flex: 1 1 auto;
+            display: flex;
+            flex-direction: column;
+            width: 100%;
+        }
     }
 
     .roll-bar {


### PR DESCRIPTION
## Summary
- fix dice area height stretch by adding .results-container flex layout
- switch to html-to-image for Discord screenshots

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685e87cbdd6c83219df12ebc7396ffc1