### PR TITLE
Display Discord webhook names

### DIFF
--- a/src/model/settings.ts
+++ b/src/model/settings.ts
@@ -87,6 +87,7 @@ class ThemeSettings extends Settings<ThemeOptions> {
 export const Theme = new ThemeSettings();
 
 export const Webhooks = new Settings<string[]>("webhooks", []);
+export const WebhookNames = new Settings<string[]>("webhook_names", []);
 export const WebhookPriority = new Settings<number>("webhook_priority", 0);
 
 export function getWebhook(): string | null {

--- a/src/view/menu.tsx
+++ b/src/view/menu.tsx
@@ -1,33 +1,81 @@
 import * as React from "react";
-import { Webhooks, WebhookPriority, Username, Theme, AutoDiscord } from "src/model/settings";
+import { Webhooks, WebhookNames, WebhookPriority, Username, Theme, AutoDiscord } from "src/model/settings";
 type MenuProps = { toggleCallback?: (open: boolean) => void };
 
 export default class Menu extends React.PureComponent<MenuProps> {
-    state = { webhooks: Webhooks.get().length ? Webhooks.get() : [""], priority: WebhookPriority.get(), username: Username.get() || "", theme: Theme.get() || "", autoDiscord: AutoDiscord.get() || false };
+    state = {
+        webhooks: Webhooks.get().length ? Webhooks.get() : [""],
+        names: WebhookNames.get().slice(),
+        priority: WebhookPriority.get(),
+        username: Username.get() || "",
+        theme: Theme.get() || "",
+        autoDiscord: AutoDiscord.get() || false
+    };
+
+    private webhookApi(url: string): string | null {
+        const match = url.match(/\/api\/webhooks\/(\d+)\/([^/]+)/);
+        return match ? `https://discord.com/api/webhooks/${match[1]}/${match[2]}` : null;
+    }
+
+    private async updateName(idx: number, url: string) {
+        const api = this.webhookApi(url);
+        if (!api) { return; }
+        try {
+            const res = await fetch(api);
+            if (!res.ok) { return; }
+            const data = await res.json();
+            const names = this.state.names.slice();
+            names[idx] = data.name || `Вебхук #${idx + 1}`;
+            this.setState({ names });
+            WebhookNames.set(names);
+        } catch (err) {
+            console.error(err);
+        }
+    }
 
     handleWebhook = (idx: number, e: React.ChangeEvent<HTMLInputElement>) => {
         const webhooks = this.state.webhooks.slice();
+        const names = this.state.names.slice();
         webhooks[idx] = e.target.value;
-        this.setState({ webhooks });
+        names[idx] = names[idx] || "";
+        this.setState({ webhooks, names });
         Webhooks.set(webhooks.filter(w => w));
+        WebhookNames.set(names);
+        if (webhooks[idx]) {
+            this.updateName(idx, webhooks[idx]);
+        }
     };
 
     addWebhookField = () => {
         if (this.state.webhooks.length < 5) {
-            this.setState({ webhooks: this.state.webhooks.concat([""]) });
+            this.setState({
+                webhooks: this.state.webhooks.concat([""]),
+                names: this.state.names.concat([""])
+            });
         }
     };
 
     removeWebhookField = (idx: number) => {
         if (this.state.webhooks.length > 1) {
             const webhooks = this.state.webhooks.slice();
+            const names = this.state.names.slice();
             webhooks.splice(idx, 1);
+            names.splice(idx, 1);
             const priority = Math.min(this.state.priority, webhooks.length - 1);
-            this.setState({ webhooks, priority });
+            this.setState({ webhooks, names, priority });
             Webhooks.set(webhooks.filter(w => w));
+            WebhookNames.set(names);
             WebhookPriority.set(priority);
         }
     };
+
+    componentDidMount() {
+        this.state.webhooks.forEach((hook, i) => {
+            if (hook && !this.state.names[i]) {
+                this.updateName(i, hook);
+            }
+        });
+    }
 
     handlePriority = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const priority = parseInt(e.target.value, 10);
@@ -55,7 +103,7 @@ export default class Menu extends React.PureComponent<MenuProps> {
 
     render() {
         return <div className="menu">
-            {this.state.webhooks.map((hook, i) => <label key={i}>Вебхук #{i + 1}
+            {this.state.webhooks.map((hook, i) => <label key={i}>{this.state.names[i] || `Вебхук #${i + 1}`}
               <span className="field">
                     <input type="url" value={hook} onChange={e => this.handleWebhook(i, e)} />
                     {this.state.webhooks.length > 1 && <button type="button" className="remove" onClick={() => this.removeWebhookField(i)}>×</button>}
@@ -64,7 +112,7 @@ export default class Menu extends React.PureComponent<MenuProps> {
             {this.state.webhooks.length < 5 && <button onClick={this.addWebhookField}>Добавить вебхук</button>}
             {this.state.webhooks.length > 1 && <label>Приоритетный канал
                 <select value={this.state.priority} onChange={this.handlePriority}>
-                    {this.state.webhooks.map((_, i) => <option value={i} key={"p" + i}>Вебхук #{i + 1}</option>)}
+                    {this.state.webhooks.map((_, i) => <option value={i} key={"p" + i}>{this.state.names[i] || `Вебхук #${i + 1}`}</option>)}
                 </select>
             </label>}
             <label>Имя


### PR DESCRIPTION
## Summary
- store Discord webhook names in local storage
- query Discord for the webhook name and show it in the menu

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685e9173ba108321b05e4d27eb0584f6